### PR TITLE
feat: auth & observability E2E tests (issue #3)

### DIFF
--- a/docs/kernel-file-ops.md
+++ b/docs/kernel-file-ops.md
@@ -1,0 +1,457 @@
+# Kernel File Operations
+
+## Architecture
+
+### VFS Kernel
+
+The Nexus kernel exposes a virtual file system over JSON-RPC 2.0. Every file
+operation is an RPC call to `/api/nfs/{method}` with zone context derived from
+the API key in the `Authorization` header.
+
+```text
+  Client (NexusClient)
+        |
+        | POST /api/nfs/{method}
+        | Authorization: Bearer <api_key>
+        | Body: {"jsonrpc":"2.0", "method":"...", "params":{...}, "id": N}
+        |
+        v
+  +------------------+
+  | JSON-RPC Router  |
+  +------------------+
+        |
+        v
+  +------------------+
+  | Zone Derivation  |  API key -> zone_id
+  +------------------+
+        |
+        v
+  +------------------+
+  | Permission Check |  ReBAC lookup
+  +------------------+
+        |
+        v
+  +------------------+
+  | Storage Backend  |  Content-Addressable Storage (CAS)
+  +------------------+
+```
+
+### RPC Operations
+
+| Method         | RPC Path                | Parameters                                          |
+| -------------- | ----------------------- | --------------------------------------------------- |
+| `write`        | `/api/nfs/write`        | `path`, `content` (optional `encoding`, `metadata`) |
+| `read`         | `/api/nfs/read`         | `path`                                              |
+| `delete`       | `/api/nfs/delete`       | `path`                                              |
+| `mkdir`        | `/api/nfs/mkdir`        | `path`, `parents`                                   |
+| `list`         | `/api/nfs/list`         | `path` (optional `cursor`)                          |
+| `glob`         | `/api/nfs/glob`         | `pattern`                                           |
+| `grep`         | `/api/nfs/grep`         | `pattern`, `path`                                   |
+| `rename`       | `/api/nfs/rename`       | `old_path`, `new_path`                              |
+| `copy`         | `/api/nfs/copy`         | `src_path`, `dst_path`                              |
+| `exists`       | `/api/nfs/exists`       | `path`                                              |
+| `get_metadata` | `/api/nfs/get_metadata` | `path`                                              |
+| `rmdir`        | `/api/nfs/rmdir`        | `path`, `recursive`                                 |
+
+### Response Envelope
+
+All RPC calls return an `RpcResponse` with this structure:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": { ... },
+  "error": null
+}
+```
+
+On failure, `error` is populated and `result` is null:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": null,
+  "error": { "code": -404, "message": "File not found", "data": null }
+}
+```
+
+HTTP-level errors (401, 403, 500) are wrapped as RPC errors with code
+`-{status_code}`. The client never raises on HTTP errors.
+
+### Content-Addressable Storage (CAS)
+
+Identical content written to different paths produces the same `etag`. Tests
+verify this deduplication behavior:
+
+- Write same content to two paths -> etags match
+- Rewrite identical content -> etag is stable
+- Overwrite with different content -> etag changes
+
+### Result Format Flexibility
+
+`glob()`, `list_dir()`, and `grep()` return variable formats depending on the
+server version:
+
+| Format              | Example                                                    |
+| ------------------- | ---------------------------------------------------------- |
+| List of strings     | `["/path/a.txt", "/path/b.txt"]`                           |
+| List of dicts       | `[{"name": "a.txt", "type": "file"}]`                      |
+| Dict with entries   | `{"entries": [...], "has_more": false}`                    |
+| Dict with matches   | `{"matches": [...]}` (grep)                                |
+| Dict with files     | `{"files": [...], "has_more": true, "next_cursor": "..."}` |
+
+Use `extract_paths(result)` to normalize any of these into `list[str]`.
+
+---
+
+## NexusClient API
+
+**Location:** `tests/helpers/api_client.py`
+
+### Core Classes
+
+**NexusClient** -- RPC facade with auto-incrementing request IDs:
+
+```python
+@dataclass
+class NexusClient:
+    http: httpx.Client
+    base_url: str = ""
+    api_key: str = ""
+    _rpc_id: int = field(default=0, repr=False)
+```
+
+**RpcResponse** -- immutable Pydantic model:
+
+```python
+class RpcResponse(BaseModel):
+    @property
+    def ok(self) -> bool: ...        # True if error is None
+
+    @property
+    def content_str(self) -> str: ...  # Decode result as string
+        # Handles: plain string, base64 bytes, nested dict
+```
+
+**CliResult** -- frozen dataclass for subprocess output:
+
+```python
+@dataclass(frozen=True)
+class CliResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool: ...  # exit_code == 0
+```
+
+### Zone Client Factory
+
+```python
+def for_zone(self, zone_api_key: str) -> NexusClient:
+    """New client with dedicated httpx session bound to zone key.
+    Caller must close the returned client's http session."""
+```
+
+---
+
+## Assertion Helpers
+
+**Location:** `tests/helpers/assertions.py`
+
+| Helper                                           | Purpose                                        |
+| ------------------------------------------------ | ---------------------------------------------- |
+| `assert_rpc_success(resp)`                       | Assert `resp.ok`, return `resp.result`         |
+| `assert_rpc_error(resp, *, code, msg_contains)`  | Assert error with optional code/message match  |
+| `assert_file_roundtrip(nexus, path, content)`    | Write then read, assert content matches        |
+| `assert_file_not_found(nexus, path)`             | Assert read returns error                      |
+| `assert_directory_contains(nexus, path, names)`  | Assert listing contains expected entries       |
+| `assert_cli_success(result)`                     | Assert `exit_code == 0`, return stdout         |
+| `assert_cli_error(result, *, stderr_contains)`   | Assert non-zero exit code                      |
+| `extract_paths(result)`                          | Normalize glob/grep/list results to `list[str]`|
+
+### extract_paths
+
+Handles all result format variations with bounded recursion (depth <= 3):
+
+```python
+def extract_paths(result: object, *, _depth: int = 0) -> list[str]:
+    # List of dicts -> extract "path" or "name" field
+    # List of strings -> convert directly
+    # Dict with "entries"/"matches"/"files" -> recurse
+```
+
+---
+
+## Data Generators
+
+**Location:** `tests/helpers/data_generators.py`
+
+### generate_tree
+
+Creates a file tree of configurable depth and breadth:
+
+```python
+def generate_tree(nexus: NexusClient, base_path: str, *,
+                  depth: int = 3, breadth: int = 3) -> TreeStats:
+```
+
+```text
+{base_path}/
+├── data.txt
+├── dir_0/
+│   ├── data.txt
+│   ├── dir_0/ ...
+│   └── dir_{breadth-1}/
+├── dir_1/ ...
+└── dir_{breadth-1}/ ...
+```
+
+Returns `TreeStats(files_created, dirs_created, total_bytes, base_path)` (frozen).
+
+### load_benchmark_files
+
+```python
+def load_benchmark_files(benchmark_dir: str | Path) -> dict[str, list[Path]]:
+    # Recursively scan, group by extension
+    # Returns {".txt": [Path, ...], ".json": [Path, ...]}
+    # Empty dict if directory missing
+```
+
+### seed_herb_data
+
+```python
+def seed_herb_data(nexus: NexusClient, zone: str,
+                   benchmark_dir: str | Path, *,
+                   max_files: int = 100) -> SeedResult:
+    # Load benchmark files, write to /seed-data/{filename}
+    # Returns SeedResult(files_seeded, zones_seeded, errors) (frozen)
+```
+
+---
+
+## Test Setup
+
+### Server Startup
+
+```bash
+docker compose -f dockerfiles/docker-compose.cross-platform-test.yml up -d
+```
+
+The session-scoped `_cluster_ready` fixture (autouse) blocks until
+`GET /health` returns OK, with exponential backoff up to
+`settings.cluster_wait_timeout` (default 120s). The entire session is skipped if
+the cluster is unreachable.
+
+### Running Tests
+
+```bash
+pytest -m quick              # Smoke tests (<2 min)
+pytest -m auto               # Full regression
+pytest -m stress             # Concurrency and large data
+pytest -m kernel             # All kernel tests
+pytest -m "quick and kernel" # Fast kernel smoke tests
+pytest -m "auto or perf"     # Regression + benchmarks
+```
+
+### Test Markers
+
+| Marker       | Purpose                                  |
+| ------------ | ---------------------------------------- |
+| `quick`      | Smoke tests, fast runtime                |
+| `auto`       | Full regression suite                    |
+| `stress`     | Concurrency, large data, resource limits |
+| `perf`       | Performance benchmarks                   |
+| `kernel`     | Core FS operations                       |
+| `zone`       | Multi-tenancy isolation                  |
+| `federation` | Multi-node replication                   |
+| `hooks`      | VFS pre/post write hooks                 |
+| `dangerous`  | May crash server or corrupt data         |
+| `property`   | Property-based / fuzz testing            |
+| `chaos`      | Fault injection, partition, corruption   |
+
+### Hypothesis Profiles
+
+Set via `HYPOTHESIS_PROFILE` env var:
+
+| Profile    | max_examples | deadline | Notes                       |
+| ---------- | ------------ | -------- | --------------------------- |
+| `dev`      | 10           | 500ms    | Default, fast local dev     |
+| `ci`       | 1,000        | None     | Derandomized, deterministic |
+| `thorough` | 100,000      | None     | Full fuzzing, all phases    |
+
+---
+
+## Fixture Architecture
+
+### Scoping Strategy
+
+```text
+Session-scoped (created once)
+  settings            TestSettings from env / .env.test
+  http_client         httpx.Client (leader, auth, pooling)
+  follower_http_client  httpx.Client (follower node)
+  nexus               NexusClient (leader, admin)
+  nexus_follower      NexusClient (follower)
+  _cluster_ready      Health check gate (autouse)
+  benchmark_data      Lazy-loaded benchmark files
+
+Module-scoped
+  scratch_zone        Pre/post cleans /test-data, returns zone ID
+
+Function-scoped (per test)
+  worker_id           pytest-xdist worker ID or "main"
+  unique_path         /test-{worker_id}/{uuid[:8]}/
+  make_file           File factory with auto-cleanup
+  kernel_tree         Pre-built 3-level test tree
+```
+
+### unique_path
+
+Generates a collision-free path prefix per test using the xdist worker ID and a
+UUID fragment:
+
+```text
+/test-main/a1b2c3d4/
+/test-gw0/e5f6a7b8/
+```
+
+### make_file  (function)
+
+Factory callable that creates files and deletes them on teardown:
+
+```python
+def make_file(name: str, content: str = "test content") -> str:
+    # Writes {unique_path}/{name} via nexus.write_file()
+    # Tracks path for cleanup
+    # Returns full path
+```
+
+Cleanup iterates in reverse order, suppressing exceptions.
+
+### kernel_tree  (function)
+
+**Location:** `tests/kernel/conftest.py`
+
+Creates a small 3-level tree for glob/grep/listing tests:
+
+```text
+{unique_path}/tree/
+├── root.txt          "root content"
+├── level1_a/
+│   ├── a.txt         "level 1a content"
+│   └── level2_a/
+│       └── deep.txt  "level 2 deep content"
+└── level1_b/
+    └── b.py          "print('hello')"
+```
+
+Yields `{"base": str, "files": list[str], "dirs": list[str]}`.
+
+---
+
+## Test Coverage
+
+### CRUD  (`tests/kernel/test_crud.py`)
+
+| ID         | Test                   | Markers     | Operations                |
+| ---------- | ---------------------- | ----------- | ------------------------- |
+| kernel/001 | Write-read roundtrip   | quick, auto | write, read               |
+| kernel/002 | Overwrite changes etag | quick, auto | write x2, etag compare    |
+| kernel/003 | Delete file            | quick, auto | write, delete, read       |
+| kernel/004 | Mkdir and list         | quick, auto | mkdir, write, list        |
+| kernel/005 | Nested mkdir           | quick, auto | mkdir(parents=True)       |
+| kernel/006 | Rmdir empty            | quick, auto | mkdir, rmdir              |
+| kernel/007 | Rmdir recursive        | quick, auto | write, rmdir(recursive)   |
+| kernel/008 | Rename                 | quick, auto | write, rename, read       |
+| kernel/009 | Copy                   | quick, auto | write, copy, read (xfail) |
+| kernel/010 | Tree view              | quick, auto | write, list, glob         |
+
+### Glob & Grep  (`tests/kernel/test_glob_grep.py`)
+
+| ID         | Test                     | Markers     | Operations       |
+| ---------- | ------------------------ | ----------- | ---------------- |
+| kernel/011 | Glob pattern (`**/*.py`) | quick, auto | write, glob      |
+| kernel/012 | Glob exclusion           | quick, auto | write, glob x2   |
+| kernel/013 | Grep content match       | quick, auto | write, grep      |
+| kernel/014 | Grep regex               | auto        | write, grep      |
+
+### CAS & Metadata  (`tests/kernel/test_cas_metadata.py`)
+
+| ID         | Test                             | Markers | Operations                         |
+| ---------- | -------------------------------- | ------- | ---------------------------------- |
+| kernel/015 | Duplicate etag detection         | auto    | write x2, etag compare             |
+| kernel/016 | File metadata stat               | auto    | write, get_metadata                |
+| kernel/017 | Custom metadata                  | auto    | write(metadata=), get_metadata     |
+| kernel/018 | Binary file roundtrip            | auto    | write(base64), read, SHA-256       |
+| kernel/019 | Empty file                       | auto    | write(""), read                    |
+| kernel/020 | Unicode filename                 | auto    | write, read (skip if unsupported)  |
+| kernel/021 | Special chars in path            | auto    | write, read (spaces, `=`, `&`)     |
+| kernel/022 | CAS dedup hash                   | auto    | write x2, get_metadata             |
+| kernel/023 | Stable etag on identical rewrite | auto    | write x2, etag compare             |
+
+### Error Cases  (`tests/kernel/test_crud.py`)
+
+| ID         | Test                         | Markers     | Assertion                         |
+| ---------- | ---------------------------- | ----------- | --------------------------------- |
+| kernel/024 | Path traversal blocked       | quick, auto | `/../../../etc/passwd` denied     |
+| kernel/025 | Read nonexistent             | quick, auto | Returns error                     |
+| kernel/026 | Write missing parent         | quick, auto | Server-dependent                  |
+| kernel/027 | Max path length (4096 chars) | quick, auto | Error or success, no crash        |
+
+### Stress & Performance  (`tests/kernel/test_stress.py`)
+
+| ID         | Test                           | Markers      | Scale                      |
+| ---------- | ------------------------------ | ------------ | -------------------------- |
+| kernel/050 | Large file (100 MB)            | stress       | SHA-256 verified roundtrip |
+| kernel/051 | Concurrent writes (10 threads) | stress       | ThreadPoolExecutor         |
+| kernel/052 | Large flat dir ls (10K files)  | stress, perf | Paginated listing          |
+| kernel/053 | Nested glob (~4K files)        | stress, perf | depth=6, breadth=5         |
+| kernel/054 | Grep large dataset (10K files) | stress, perf | Needle every 100th file    |
+
+---
+
+## Stress Test Patterns
+
+### Parallel Write
+
+All stress tests use a shared `_parallel_write` helper:
+
+```python
+def _parallel_write(nexus: NexusClient,
+                    files: list[tuple[str, str]], *,
+                    workers: int = 20) -> tuple[int, int]:
+    # ThreadPoolExecutor with max_workers
+    # Returns (success_count, failure_count)
+```
+
+Workers scale by test: 20 for flat directory, 50 for nested glob.
+
+### Large File
+
+Deterministic 100 MB content (`b"A" * 1MB * 100`), base64-encoded for transport.
+Falls back to 10 MB text if binary encoding fails. Verified via SHA-256 checksum.
+
+### Pagination
+
+Large listing results are paginated via cursor:
+
+```python
+all_entries = []
+cursor = None
+while True:
+    result = nexus.rpc("list", {"path": base, "cursor": cursor})
+    entries = result.get("files", result.get("entries", []))
+    all_entries.extend(entries)
+    if not result.get("has_more", False):
+        break
+    cursor = result.get("next_cursor")
+```
+
+### Recovery Sleeps
+
+Stress tests include deliberate pauses (`time.sleep(3-10s)`) between tests to
+let the server recover from prior load. Timeouts are set to 300-600s per test.

--- a/docs/vfs-hooks.md
+++ b/docs/vfs-hooks.md
@@ -1,0 +1,225 @@
+# VFS Hooks
+
+## Architecture
+
+### KernelDispatch Two-Phase Model
+
+VFS hooks follow a two-phase dispatch model:
+
+| Phase     | Timing          | Semantics           | Failure behavior                |
+|-----------|-----------------|---------------------|---------------------------------|
+| INTERCEPT | Synchronous     | Ordered by priority | Can abort (via `AuditLogError`) |
+| OBSERVE   | Fire-and-forget | Unordered           | Exceptions become warnings      |
+
+```text
+  VFS write request
+        |
+        v
+  +-------------+
+  | Backend      |
+  | Commit       |  <-- data persisted to storage
+  +-------------+
+        |
+        v
+  +-------------------------------+
+  | KernelDispatch                |
+  |  .intercept_post_write()      |
+  |                               |
+  |  Hook B  -->  Hook A          |  INTERCEPT phase (ordered)
+  |  (priority)   (priority)      |
+  +-------------------------------+
+        |
+        |--- AuditLogError? --> client receives error
+        |                       (data stays committed)
+        |
+        v
+  +-------------------------------+
+  | KernelDispatch                |
+  |  .notify_observers()          |
+  |                               |
+  |  Observer 1, Observer 2 ...   |  OBSERVE phase (fire-and-forget)
+  +-------------------------------+
+        |
+        v
+  Response to client
+```
+
+### Post-Operation Only Design
+
+All hooks execute **after** the file operation completes. Data is committed to
+storage before any hook runs. Hooks cannot prevent the write -- they can only
+signal errors after commit.
+
+This means:
+
+- `BlockedPathHook` raises `AuditLogError` for paths under `/blocked/`, but the
+  file data **is already persisted** in storage
+- The client receives an error response, but cleanup does not happen automatically
+- Tests must account for files existing even when the hook "rejected" the write
+
+### AuditLogError Abort Behavior
+
+`AuditLogError` is the mechanism for hooks to signal operation failure:
+
+1. Hook executes after write commits
+2. Hook raises `AuditLogError`
+3. RPC response is transformed to error status
+4. Client sees `RpcResponse.ok == False`
+5. File data remains in storage (post-operation semantics)
+
+Other exceptions raised by hooks become **warnings** and do not affect the
+client response.
+
+### Hook Registration
+
+Hooks are registered server-side during initialization when `NEXUS_TEST_HOOKS=true`
+is set. The registration code lives in `nexus/core/test_hooks.py` and populates
+the `KernelDispatch` instance at boot time.
+
+---
+
+## Test Setup
+
+### Server Startup
+
+Start the server with test hooks enabled:
+
+```bash
+NEXUS_TEST_HOOKS=true docker compose -f dockerfiles/docker-compose.cross-platform-test.yml up -d
+```
+
+This registers three test hooks and exposes the test hook REST API. Without this
+flag, all hook tests are automatically skipped.
+
+### Three Test Hooks
+
+| Hook            | Phase     | Behavior                                                      |
+|-----------------|-----------|---------------------------------------------------------------|
+| AuditMarkerHook | INTERCEPT | Records audit markers (path, timestamp, size) on every write  |
+| BlockedPathHook | INTERCEPT | Raises `AuditLogError` for paths under `/blocked/`            |
+| ChainOrderHook  | INTERCEPT | Two instances (B, A) record execution order as a trace string |
+
+No OBSERVE-phase test hooks are currently registered; the architecture supports
+them but existing tests only exercise the INTERCEPT phase.
+
+**ChainOrderHook ordering**: Instance B is registered before A, so the expected
+execution trace is `"BA"`.
+
+### REST API: /api/test-hooks/*
+
+The test hook endpoints allow tests to query hook state after writes:
+
+**Hook availability check:**
+
+```text
+GET /api/test-hooks/state
+200 = hooks available
+```
+
+**Audit marker query:**
+
+```text
+GET /api/test-hooks/audit/{path_hash}
+```
+
+```json
+{
+    "found": true,
+    "path": "/test-hooks/.../data.txt",
+    "timestamp": 1234567890.5,
+    "size": 42
+}
+```
+
+**Chain order query:**
+
+```text
+GET /api/test-hooks/chain/{path_hash}
+```
+
+```json
+{
+    "found": true,
+    "trace": "BA"
+}
+```
+
+`path_hash` is the first 16 hex characters of `SHA256(path)`:
+
+```python
+def path_hash(path: str) -> str:
+    return hashlib.sha256(path.encode()).hexdigest()[:16]
+```
+
+### Contract Constants
+
+Defined in `tests/hooks/conftest.py` (must match `nexus/core/test_hooks.py`):
+
+```python
+HOOK_BLOCKED_PREFIX  = "/blocked/"
+HOOK_TEST_ENDPOINT   = "/api/test-hooks"
+CHAIN_EXPECTED_ORDER = "BA"
+```
+
+---
+
+## Fixture Architecture
+
+### Auto-Skip
+
+An `autouse=True` fixture runs before every test in the `tests/hooks/` module:
+
+```python
+@pytest.fixture(autouse=True)
+def _skip_if_hooks_unavailable(nexus: NexusClient) -> None:
+    if not _hooks_available(nexus):
+        pytest.skip(
+            "Test hooks not available. "
+            "Start server with NEXUS_TEST_HOOKS=true"
+        )
+```
+
+`_hooks_available()` calls `GET /api/test-hooks/state` and returns `True` only
+on a 200 response.
+
+### Fixture Summary
+
+| Fixture                      | Scope    | Purpose                                                 |
+| ---------------------------- | -------- | ------------------------------------------------------- |
+| `_skip_if_hooks_unavailable` | function | Auto-skip if server lacks hook support                  |
+| `hook_test_path`             | function | Unique path for positive hook tests                     |
+| `blocked_path`               | function | Unique path under `/blocked/` for rejection tests       |
+| `nexus`                      | session  | Admin NexusClient (from root conftest)                  |
+| `worker_id`                  | function | pytest-xdist worker ID or `"main"`                      |
+
+### hook_test_path  (function)
+
+Generates a unique file path **not** under `/blocked/` for positive hook tests:
+
+```text
+/test-hooks/{worker_id}/{uuid[:8]}/data.txt
+```
+
+### blocked_path  (function)
+
+Generates a unique file path under the blocked prefix for rejection tests:
+
+```text
+/blocked/{worker_id}/{uuid[:8]}/secret.txt
+```
+
+### Test Classes
+
+**TestHookInvocation** -- verifies hooks fire on write:
+
+- `hooks/001`: Write file, query audit endpoint, assert `found == true` and path matches
+- `hooks/002`: Write file, assert audit marker contains numeric `timestamp` and `size > 0`
+
+**TestHookRejection** -- verifies blocked-path behavior:
+
+- `hooks/003`: Write to blocked path, assert `resp.ok == False` (cleanup: file may exist)
+- Positive control: write to non-blocked path, assert success and content match
+
+**TestHookChainOrdering** -- verifies hook priority:
+
+- `hooks/004`: Write file, query chain endpoint, assert `trace == "BA"`

--- a/docs/zone-isolation.md
+++ b/docs/zone-isolation.md
@@ -1,0 +1,260 @@
+# Zone Isolation
+
+## Architecture
+
+### Zone Derivation
+
+The Nexus server extracts the **zone from the API key**, not from RPC parameters.
+Every VFS call carries a `Bearer <zone_api_key>` header; the server resolves the
+key to a `zone_id` and enforces isolation before the operation reaches storage.
+
+Admin keys bypass zone isolation entirely.
+
+```
+                      API Key
+                        |
+                        v
+               +------------------+
+               | Zone Derivation  |
+               | (key -> zone_id) |
+               +------------------+
+                        |
+            +-----------+-----------+
+            |                       |
+        admin key              zone-scoped key
+            |                       |
+            v                       v
+      bypass isolation     +------------------+
+                           | Permission Check |
+                           | (ReBAC lookup)   |
+                           +------------------+
+                                    |
+                              +-----+-----+
+                              |           |
+                           granted      denied
+                              |           |
+                              v           v
+                     +------------+   403 error
+                     | Data Access|
+                     +------------+
+```
+
+### Isolation Layers
+
+**Layer 1 -- ReBAC zone_id filtering (primary)**
+
+Relationship-Based Access Control enforces zone boundaries via `rebac_tuples`.
+Each zone-scoped key can only access objects whose `zone_id` matches the key's
+zone. Grants are scoped to path prefixes (e.g. `/test-zone-corp`).
+
+```sql
+INSERT OR IGNORE INTO rebac_tuples
+  (tuple_id, zone_id, subject_zone_id, object_zone_id,
+   subject_type, subject_id, subject_relation, relation,
+   object_type, object_id, created_at, expires_at, conditions)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+```
+
+**Layer 2 -- Owner fast-path bypass prevention**
+
+Tests use **different `user_id` values** per zone to prevent the owner fast-path
+from short-circuiting ReBAC checks:
+
+| Zone   | user_id              |
+|--------|----------------------|
+| Zone A | `test-user-zone-a`   |
+| Zone B | `test-user-zone-b`   |
+
+**Layer 3 -- Path-prefix strategy**
+
+Each zone is bound to a unique path prefix derived from its zone ID:
+
+| Zone   | Path prefix                          | Default              |
+|--------|--------------------------------------|----------------------|
+| Zone A | `/test-zone-{settings.zone}`         | `/test-zone-corp`    |
+| Zone B | `/test-zone-{settings.scratch_zone}` | `/test-zone-corp-eng`|
+
+A zone-scoped key has no ReBAC grant for another zone's prefix, so cross-zone
+writes and reads are denied even if the underlying storage is shared.
+
+### Standalone Limitation
+
+`RaftMetadataStore` (used in standalone mode) does not support `zone_id` filtering
+for list/glob operations. Zone-scoped clients attempting glob across zone boundaries
+receive permission errors -- this is the intended isolation behavior, but it means
+there is no positive control for glob without an admin client in standalone mode.
+
+---
+
+## Test Setup
+
+### Server Startup
+
+Start the federation cluster (3-node Raft with zones):
+
+```bash
+docker compose -f dockerfiles/docker-compose.cross-platform-test.yml up -d
+```
+
+Pre-configured zone mounts in the compose file:
+
+```
+/corp=corp
+/corp/engineering=corp-eng
+/corp/sales=corp-sales
+/family=family
+/family/work=corp
+```
+
+### Key Environment Variables
+
+All variables use the `NEXUS_TEST_` prefix and can be set in `.env.test`:
+
+| Variable                         | Default                                            | Purpose                        |
+|----------------------------------|----------------------------------------------------|--------------------------------|
+| `NEXUS_TEST_URL`                 | `http://localhost:2026`                             | Leader node endpoint           |
+| `NEXUS_TEST_URL_FOLLOWER`        | `http://localhost:2027`                             | Follower node endpoint         |
+| `NEXUS_TEST_API_KEY`             | `sk-test-federation-e2e-admin-key`                  | Admin API key                  |
+| `NEXUS_TEST_ZONE`               | `corp`                                              | Primary zone ID                |
+| `NEXUS_TEST_SCRATCH_ZONE`       | `corp-eng`                                          | Secondary zone ID              |
+| `NEXUS_TEST_DATABASE_URL`        | `postgresql://postgres:nexus@localhost:5432/nexus`  | RecordStore connection         |
+| `NEXUS_TEST_REQUEST_TIMEOUT`     | `30.0`                                              | HTTP timeout (seconds)         |
+| `NEXUS_TEST_CLUSTER_WAIT_TIMEOUT`| `120.0`                                             | Cluster readiness timeout      |
+
+### TestSettings
+
+`tests/config.py` defines a Pydantic `BaseSettings` class that loads config from
+environment variables (prefix `NEXUS_TEST_`) or `.env.test`:
+
+```python
+class TestSettings(BaseSettings):
+    url: str = "http://localhost:2026"
+    url_follower: str = "http://localhost:2027"
+    api_key: str = "sk-test-federation-e2e-admin-key"
+    zone: str = "corp"                    # primary zone
+    scratch_zone: str = "corp-eng"        # secondary zone
+    request_timeout: float = 30.0
+    cluster_wait_timeout: float = 120.0
+    # ...
+```
+
+Validation rejects production URLs (containing "prod", "staging", ".cloud", ".io").
+
+### SQLite Fallback for Zone/Key Creation
+
+The REST API for zone and key management requires a JWT, which the test harness
+may not have. The helpers in `tests/helpers/zone_keys.py` fall back to **direct
+SQLite insertion** when the RPC call fails.
+
+**Database discovery** (`_find_db_path`) searches in order:
+
+1. `NEXUS_TEST_DB_PATH` env var
+2. `~/nexus/test-e2e-data/nexus.db`
+3. `~/nexus/nexus-data/nexus.db`
+4. `./nexus.db`
+
+**Zone creation** (`create_zone_direct`):
+
+```sql
+INSERT OR IGNORE INTO zones
+  (zone_id, name, domain, description, settings,
+   phase, finalizers, deleted_at, created_at, updated_at)
+VALUES (?, ?, NULL, NULL, NULL, 'Active', '[]', NULL, ?, ?)
+```
+
+**API key creation** (`_create_key_direct`):
+
+```
+Key format:  sk-<zone[:8]>_<user[:8]>_<key_id_hex>_<random_hex>
+Key hash:    HMAC-SHA256(salt="nexus-api-key-v1", message=raw_key)
+```
+
+```sql
+INSERT INTO api_keys
+  (key_id, key_hash, user_id, subject_type, subject_id,
+   zone_id, is_admin, inherit_permissions, name, created_at, revoked)
+VALUES (?, ?, ?, 'user', ?, ?, 0, 0, ?, ?, 0)
+```
+
+**Zone deletion** (`delete_zone_direct`) cascades cleanup:
+
+1. Set `zones.phase = 'Terminated'`
+2. Revoke all API keys for the zone
+3. Delete all ReBAC tuples for the zone
+
+---
+
+## Fixture Architecture
+
+### Scoping Strategy
+
+```
+Session-scoped (created once)
+  settings          TestSettings loaded from env
+  http_client       httpx.Client with admin auth
+  nexus             Admin NexusClient
+  zone_a_root       "/test-zone-{zone}"       path prefix
+  zone_b_root       "/test-zone-{scratch_zone}" path prefix
+  nexus_a           Zone A client (non-admin)
+  nexus_b           Zone B client (non-admin)
+
+Function-scoped (per test)
+  make_file_a       File factory for zone A with auto-cleanup
+  make_file_b       File factory for zone B with auto-cleanup
+  ephemeral_zone    Unique zone per test (UUID-based)
+  zone_a            Zone A ID string
+  zone_b            Zone B ID string
+```
+
+### nexus_a / nexus_b  (session)
+
+Each zone client is created with three steps:
+
+1. **Create zone-scoped API key** via `create_zone_key()` (tries RPC, falls back
+   to SQLite)
+2. **Grant ReBAC permission** on the zone's path prefix via
+   `grant_zone_permission(zone_id, user_id, path_prefix)`
+3. **Instantiate client** via `nexus.for_zone(raw_key)` -- returns a new
+   `NexusClient` with its own `httpx.Client` session bound to the zone key
+
+```python
+# Zone A
+raw_key = create_zone_key(nexus, settings.zone, name="test-zone-a-key",
+                          user_id="test-user-zone-a")
+grant_zone_permission(settings.zone, "test-user-zone-a", zone_a_root)
+client_a = nexus.for_zone(raw_key)
+
+# Zone B
+raw_key = create_zone_key(nexus, settings.scratch_zone, name="test-zone-b-key",
+                          user_id="test-user-zone-b")
+grant_zone_permission(settings.scratch_zone, "test-user-zone-b", zone_b_root)
+client_b = nexus.for_zone(raw_key)
+```
+
+### make_file_a / make_file_b  (function)
+
+Factory callables that auto-prefix paths with the zone root and register files
+for cleanup on teardown:
+
+```python
+def _make(relative_path: str, content: str) -> str:
+    full_path = f"{zone_root}/{relative_path.lstrip('/')}"
+    assert_rpc_success(client.write_file(full_path, content))
+    created.append(full_path)
+    return full_path
+
+# Usage:
+path = make_file_a("isolation/cross_zone.txt", "hello")
+# Writes to /test-zone-corp/isolation/cross_zone.txt
+```
+
+Cleanup iterates in reverse order, suppressing exceptions.
+
+### ephemeral_zone  (function)
+
+Creates a UUID-based zone for single-test use:
+
+- **ID format**: `test-{worker_id}-{uuid[:8]}` (pytest-xdist safe)
+- **Creation**: tries REST `POST /api/zones` first, falls back to SQLite
+- **Teardown**: tries REST `DELETE /api/zones/{id}`, falls back to `delete_zone_direct()`
+- **Skip**: if neither creation method works, the test is skipped


### PR DESCRIPTION
## Summary

- Add 15 test IDs (20 test functions) for authentication and observability as specified in TEST_PLAN.md §4.4 and §4.40
- Add `hook_file` auto-cleanup fixture to DRY-up hooks tests
- Add `scripts/serve-for-tests.sh` for test server startup
- Add documentation for auth/sessions and observability architecture

### Auth tests (auth/001-005)
- **auth/001**: Valid API key → `authenticated=true`
- **auth/002**: Invalid auth rejection (4 parametrized modes: no header, empty, malformed, nonexistent)
- **auth/003**: Rate limiting (anonymous burst + header check, skip-if-disabled)
- **auth/004**: API key lifecycle (create → use → revoke → verify 401, skip-if-unavailable)
- **auth/005**: Whoami field verification (admin + zone key)

### Observability tests (obs/001-010)
- **obs/001-002**: Health endpoints (basic + detailed with component checks)
- **obs/003-005**: Kubernetes probes (liveness, readiness with 503 handling, startup)
- **obs/006**: Features endpoint (profile, enabled_bricks)
- **obs/007**: Operations log (write → verify entry, skip on 500)
- **obs/008-010**: Prometheus metrics (latency histogram, error counter, saturation gauge)

### Bugs filed during testing
- [nexi-lab/nexus#2588](https://github.com/nexi-lab/nexus/issues/2588) — `admin_create_key` crashes with `DiscriminatingAuthProvider`
- [nexi-lab/nexus#2589](https://github.com/nexi-lab/nexus/issues/2589) — `/api/v2/operations` returns 500 (record_store attribute mismatch)
- [nexi-lab/nexus#2590](https://github.com/nexi-lab/nexus/issues/2590) — No REST endpoint for API key management

## Test plan
- [x] `uv run pytest tests/auth/ tests/obs/ -v` — 15 passed, 5 skipped, 0 failed
- [x] `uv run pytest tests/hooks/ -v` — 5 passed (no regressions from hook_file refactor)
- [x] `uv run pytest -m auth --collect-only` — 10 tests collected
- [x] `uv run pytest -m observability --collect-only` — 10 tests collected
- [x] `uv run ruff check` — clean (only pre-existing E501 in assertions.py)
- [x] Full suite regression: 57 passed, 5 skipped, 1 xfailed