### PR TITLE
Add priority rankings and search/RAG benchmarks to TEST_PLAN

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -120,9 +120,15 @@ docker start nexus-node-1
 | `benchmarks/memory/longmemeval/` | LongMemEval_S (500 Qs, 40 sessions, ~115K tokens) | memory/014 temporal, memory/016 abstention |
 | `benchmarks/memory/locomo/` | LoCoMo (10 convos × 300 turns × 35 sessions) + MC10 variant | memory/014 temporal, memory/015 multi-session |
 | `benchmarks/memory/memoryagentbench/` | MemoryAgentBench (FactConsolidation + EventQA + LRU subsets) | memory/015 multi-session, memory/017 conflict |
+| `benchmarks/memory/memoryarena/` | MemoryArena (interdependent multi-session agentic tasks) | memory/015 multi-session (agentic gap test) |
 | `benchmarks/memory/tofu/` | TOFU (200 fictitious profiles, forget/retain splits) | memory/018 selective forgetting |
 | `benchmarks/memory/ultradomain/` | UltraDomain (4 domains, 600K–5M tokens from 428 textbooks) | memory/021 context saturation |
 | `benchmarks/memory/graphrag-bench/` | GraphRAG-Bench (16 disciplines, multi-format Qs) | memory/023 multi-agent isolation |
+| `benchmarks/search/hotpotqa/` | HotPotQA (113K multi-hop Q&A pairs with supporting facts) | search/002 semantic, llm/003 RAG |
+| `benchmarks/search/beir/` | BEIR subsets (NFCorpus, SciFact, FiQA — 3 domains) | search/002 semantic search quality |
+| `benchmarks/search/multihop-rag/` | MultiHop-RAG (multi-hop queries over news with evidence chains) | llm/003 RAG pipeline |
+| `benchmarks/search/musique/` | MuSiQue (compositional 2–4 hop QA with unanswerable Qs) | llm/003 RAG pipeline |
+| `benchmarks/search/codesearchnet/` | CodeSearchNet (2M comment/code pairs, 6 languages) | search/007 code search |
 
 ---
 
@@ -360,28 +366,45 @@ Test IDs follow `nxfs/{feature}/{NNN}` (e.g., `nxfs/kernel/001`).
 Each new test maps to established benchmarks and open-source datasets. Use these
 as reference data, evaluation methodology, and ground-truth baselines.
 
-| Test ID | Benchmark / Dataset | Source | How to Obtain | What It Provides |
-|---------|-------------------|--------|---------------|------------------|
-| memory/014 | **LongMemEval** (ICLR 2025) | [GitHub](https://github.com/xiaowu0162/LongMemEval) / [HuggingFace](https://huggingface.co/datasets) | `git clone https://github.com/xiaowu0162/LongMemEval` → `data/` folder; also on HuggingFace | 500 curated questions across 40–500 sessions with timestamps. Temporal reasoning subset tests "when did X happen?" and time-scoped retrieval. Use `LongMemEval_S` (~115K tokens) for CI, `LongMemEval_M` (~500 sessions) for stress. |
-| memory/014 | **LoCoMo** (ACL 2024) | [GitHub](https://github.com/snap-research/locomo) / [HuggingFace](https://huggingface.co/datasets/Percena/locomo-mc10) | `git clone https://github.com/snap-research/locomo` | 10 conversations × 300 turns × 35 sessions. Temporal question subset with ground-truth. LoCoMo-MC10 variant (1,986 items, 10-option MC) on HuggingFace for automated eval. |
-| memory/015 | **LoCoMo multi-hop subset** | [GitHub](https://github.com/snap-research/locomo) | Same as above, filter `question_type=multi-hop` | Multi-hop questions requiring synthesis across sessions. F1 + BLEU-1 + LLM-as-judge metrics. |
-| memory/015 | **MemoryAgentBench** (ICLR 2026) | [GitHub](https://github.com/HUST-AI-HYZ/MemoryAgentBench) / [HuggingFace](https://huggingface.co/datasets/ai-hyz/MemoryAgentBench) | `pip install` + auto-download on first run | "Long-Range Understanding" competency subset. Multi-turn format simulating incremental info across sessions. |
-| memory/016 | **LongMemEval abstention subset** | [GitHub](https://github.com/xiaowu0162/LongMemEval) | Filter questions where `answer_type=unanswerable` | Tests whether system returns "I don't know" vs. hallucinating. 30% of questions designed to have no answer in memory. |
-| memory/016 | **HERB unanswerable Q&A** (local) | `benchmarks/herb/qa/` | Already in repo — 699 unanswerable questions with ground truth | Cross-reference with memory store: after populating memory with HERB context, query with unanswerable Qs and verify abstention. |
-| memory/017 | **MemoryAgentBench FactConsolidation** | [HuggingFace](https://huggingface.co/datasets/ai-hyz/MemoryAgentBench) | Auto-download; `Single-Hop FactConsolidation` + `Multi-Hop FactConsolidation` subsets | Contradictory facts injected at different turns. Measures whether system resolves to latest fact or surfaces conflict. Also see Zep/Graphiti bi-temporal model for methodology. |
-| memory/017 | **Zep/Graphiti temporal KG** methodology | [Paper](https://arxiv.org/abs/2501.13956) / [Graphiti](https://github.com/getzep/graphiti) | Reference architecture; adapt bi-temporal validity-interval approach | Bi-temporal model tracks event-time vs. ingestion-time. Every edge has validity intervals — use as design reference for conflict detection. |
-| memory/018 | **TOFU** (Task of Fictitious Unlearning) | [GitHub](https://github.com/locuslab/tofu) / [HuggingFace](https://huggingface.co/datasets/locuslab/TOFU) | `datasets.load_dataset("locuslab/TOFU")` | 200 fictitious author profiles. Forget subset + retain subset. Verify that after "forget entity X", queries about X return nothing while other memories intact. |
-| memory/018 | **Machine Unlearning methodology** | [Survey](https://github.com/tamlhp/awesome-machine-unlearning) | Reference checklist | Evaluation criteria: (1) completeness — forgotten data truly gone, (2) no side effects — retained data unaffected, (3) verifiability — audit trail of deletion. |
-| memory/019 | **Cognee evals methodology** | [Blog](https://www.cognee.ai/blog/deep-dives/ai-memory-evals-0825) | Reference methodology | Cognee benchmarked Mem0, LightRAG, Graphiti with HotPotQA (24 multi-hop Qs × 45 runs). Use EM + F1 + DeepEval + correctness metrics to detect silent degradation. |
-| memory/019 | **Custom corruption harness** | Design from [Anatomy of Agentic Memory](https://arxiv.org/html/2602.19320) | Build in-repo | Inject bit-flipped / truncated / stale memories. Verify system detects inconsistency via checksums or semantic validation rather than serving corrupted data silently. |
-| memory/020 | **Mem0 benchmark methodology** | [Paper](https://arxiv.org/abs/2504.19413) / [Blog](https://mem0.ai/research) | Reference SLO methodology | Mem0 measures Token Consumption + Latency per query on LoCoMo. Use same methodology: measure write p95, consolidation wall-time, token cost per memory op. |
-| memory/020 | **Letta Leaderboard** | [Blog](https://www.letta.com/blog/letta-leaderboard) | Reference | Letta tracks latency + token usage across models. Use as baseline comparison for our write + consolidation SLOs. |
-| memory/021 | **Context saturation gap (Δ)** methodology | [Anatomy of Agentic Memory](https://arxiv.org/html/2602.19320) | Build in-repo; reference paper | Metric Δ = accuracy(memory-assisted) − accuracy(full-context-stuffing). If Δ ≤ 0, memory system adds no value. Use HERB Q&A ground truth to measure both approaches. |
-| memory/021 | **LightRAG / UltraDomain** | [GitHub](https://github.com/HKUDS/LightRAG) / [HuggingFace](https://huggingface.co/datasets) | `git clone https://github.com/HKUDS/LightRAG` → `datasets/` | 4 domains (Agriculture, CS, Legal, Mix) from 428 textbooks, 600K–5M tokens. Compare chunk-based vs. graph-based vs. full-context retrieval accuracy. |
-| memory/022 | **MemoryBench procedural subset** | [Paper](https://arxiv.org/html/2510.17281v1) | Reference methodology; 20K cases across 3 domains | Procedural memory evaluation: inject explicit feedback (like/dislike) and implicit feedback (copy, session-close). Verify subsequent responses improve on same task type. |
-| memory/022 | **Letta dynamic memory eval** | [Blog](https://www.letta.com/blog/benchmarking-ai-agent-memory) | Reference | Tests whether agent learns *when* to use memory tools, not just retrieval accuracy. Adapt for feedback-loop testing. |
-| memory/023 | **GraphRAG-Bench** | [GitHub](https://github.com/GraphRAG-Bench/GraphRAG-Benchmark) / [HuggingFace](https://huggingface.co/datasets/GraphRAG-Bench/GraphRAG-Bench) | `datasets.load_dataset("GraphRAG-Bench/GraphRAG-Bench")` | 16 disciplines, multi-format questions. Use to validate that agent-scoped graph partitions return correct answers only from that agent's subgraph. |
-| memory/023 | **Zone-scoped HERB partitions** (local) | `benchmarks/herb/enterprise-context/` | Already in repo | Partition HERB data by department (eng/sales). Store as separate agent memories. Verify cross-agent isolation while shared memories remain accessible. |
+Benchmarks are ranked by priority within each test ID:
+- **P0** — Must Have: provides datasets + ground truth, directly runnable
+- **P1** — Should Have: provides supplementary datasets or validated methodology
+- **P2** — Nice to Have: reference methodology, no direct dataset (must build or adapt)
+
+**Competitive baselines:** When evaluating, compare against MemGPT/[Letta](https://www.letta.com/)
+(OS-inspired hierarchical memory, 74% on LoCoMo with simple file storage),
+[Mem0](https://mem0.ai/) (66.9% LoCoMo J-score), and [Zep](https://www.getzep.com/)
+(75.1% corrected LoCoMo J-score). These are *systems to benchmark against*, not
+benchmarks themselves.
+
+**LoCoMo reliability caveat:** Multiple groups report different LoCoMo results
+depending on experimental setup (Mem0 vs. Zep dispute shows 24% swing). Use
+LoCoMo for directional comparison but do not treat absolute scores as definitive.
+Cross-validate with LongMemEval and MemoryAgentBench.
+
+| Priority | Test ID | Benchmark / Dataset | Source | How to Obtain | What It Provides |
+|----------|---------|-------------------|--------|---------------|------------------|
+| P0 | memory/014 | **LongMemEval** (ICLR 2025) | [GitHub](https://github.com/xiaowu0162/LongMemEval) / [HuggingFace](https://huggingface.co/datasets) | `git clone https://github.com/xiaowu0162/LongMemEval` → `data/` folder; also on HuggingFace | 500 curated questions across 40–500 sessions with timestamps. Temporal reasoning subset tests "when did X happen?" and time-scoped retrieval. Use `LongMemEval_S` (~115K tokens) for CI, `LongMemEval_M` (~500 sessions) for stress. Gold standard for memory eval. |
+| P0 | memory/014 | **LoCoMo** (ACL 2024) | [GitHub](https://github.com/snap-research/locomo) / [HuggingFace](https://huggingface.co/datasets/Percena/locomo-mc10) | `git clone https://github.com/snap-research/locomo` | 10 conversations × 300 turns × 35 sessions. Temporal question subset with ground-truth. LoCoMo-MC10 variant (1,986 items, 10-option MC) on HuggingFace for automated eval. Most widely used memory benchmark (despite reliability caveats above). |
+| P0 | memory/015 | **LoCoMo multi-hop subset** | [GitHub](https://github.com/snap-research/locomo) | Same as above, filter `question_type=multi-hop` | Multi-hop questions requiring synthesis across sessions. F1 + BLEU-1 + LLM-as-judge metrics. |
+| P0 | memory/015 | **MemoryAgentBench** (ICLR 2026) | [GitHub](https://github.com/HUST-AI-HYZ/MemoryAgentBench) / [HuggingFace](https://huggingface.co/datasets/ai-hyz/MemoryAgentBench) | `pip install` + auto-download on first run | "Long-Range Understanding" competency subset. Multi-turn format simulating incremental info across sessions. Evaluates 4 core competencies: retrieval, test-time learning, long-range understanding, conflict resolution. State-of-the-art benchmark. |
+| P1 | memory/015 | **MemoryArena** (Feb 2026) | [GitHub](https://memoryarena.github.io/) / [Paper](https://arxiv.org/abs/2602.16313) | Reference methodology; datasets available | First benchmark with causally interdependent multi-session agentic tasks. Reveals that agents with near-saturated LoCoMo performance still fail on interdependent tasks. Covers web navigation, preference-constrained planning, progressive search, and sequential reasoning. |
+| P0 | memory/016 | **LongMemEval abstention subset** | [GitHub](https://github.com/xiaowu0162/LongMemEval) | Filter questions where `answer_type=unanswerable` | Tests whether system returns "I don't know" vs. hallucinating. 30% of questions designed to have no answer in memory. |
+| P0 | memory/016 | **HERB unanswerable Q&A** (local) | `benchmarks/herb/qa/` | Already in repo — 699 unanswerable questions with ground truth | Cross-reference with memory store: after populating memory with HERB context, query with unanswerable Qs and verify abstention. |
+| P0 | memory/017 | **MemoryAgentBench FactConsolidation** | [HuggingFace](https://huggingface.co/datasets/ai-hyz/MemoryAgentBench) | Auto-download; `Single-Hop FactConsolidation` + `Multi-Hop FactConsolidation` subsets | Contradictory facts injected at different turns. Measures whether system resolves to latest fact or surfaces conflict. Also see Zep/Graphiti bi-temporal model for methodology. |
+| P1 | memory/017 | **Zep/Graphiti temporal KG** methodology | [Paper](https://arxiv.org/abs/2501.13956) / [Graphiti](https://github.com/getzep/graphiti) | Reference architecture; adapt bi-temporal validity-interval approach | Bi-temporal model tracks event-time vs. ingestion-time. Every edge has validity intervals — use as design reference for conflict detection. |
+| P0 | memory/018 | **TOFU** (Task of Fictitious Unlearning) | [GitHub](https://github.com/locuslab/open-unlearning) / [HuggingFace](https://huggingface.co/datasets/locuslab/TOFU) | `datasets.load_dataset("locuslab/TOFU")` | 200 fictitious author profiles. Forget subset + retain subset. Verify that after "forget entity X", queries about X return nothing while other memories intact. Note: original `locuslab/tofu` repo superseded by `locuslab/open-unlearning` (NeurIPS D&B 2025). Also see [R-TOFU](https://aclanthology.org/2025.emnlp-main.265.pdf) (EMNLP 2025) for reasoning model unlearning. |
+| P2 | memory/018 | **Machine Unlearning methodology** | [Survey](https://github.com/tamlhp/awesome-machine-unlearning) | Reference checklist | Evaluation criteria: (1) completeness — forgotten data truly gone, (2) no side effects — retained data unaffected, (3) verifiability — audit trail of deletion. |
+| P1 | memory/019 | **Cognee evals methodology** | [Blog](https://www.cognee.ai/blog/deep-dives/ai-memory-evals-0825) | Reference methodology | Cognee benchmarked Mem0, LightRAG, Graphiti with HotPotQA (24 multi-hop Qs × 45 runs). Use EM + F1 + DeepEval + correctness metrics to detect silent degradation. |
+| P2 | memory/019 | **Custom corruption harness** | Design from [Anatomy of Agentic Memory](https://arxiv.org/html/2602.19320) | Build in-repo | Inject bit-flipped / truncated / stale memories. Verify system detects inconsistency via checksums or semantic validation rather than serving corrupted data silently. |
+| P1 | memory/020 | **Mem0 benchmark methodology** | [Paper](https://arxiv.org/abs/2504.19413) / [Blog](https://mem0.ai/research) | Reference SLO methodology | Mem0 measures Token Consumption + Latency per query on LoCoMo. Use same methodology: measure write p95, consolidation wall-time, token cost per memory op. Compare against Letta (74% LoCoMo with file storage) and Zep (75.1% corrected J-score). |
+| P2 | memory/020 | **Letta Leaderboard** | [Blog](https://www.letta.com/blog/letta-leaderboard) | Reference | Letta tracks latency + token usage across models. Letta Filesystem achieves 74% on LoCoMo with simple file-based storage, setting a strong "naive" baseline. Use as baseline comparison for our write + consolidation SLOs. |
+| P1 | memory/021 | **Context saturation gap (Δ)** methodology | [Anatomy of Agentic Memory](https://arxiv.org/html/2602.19320) | Build in-repo; reference paper | Metric Δ = accuracy(memory-assisted) − accuracy(full-context-stuffing). If Δ ≤ 0, memory system adds no value. Use HERB Q&A ground truth to measure both approaches. |
+| P1 | memory/021 | **LightRAG / UltraDomain** | [GitHub](https://github.com/HKUDS/LightRAG) / [HuggingFace](https://huggingface.co/datasets) | `git clone https://github.com/HKUDS/LightRAG` → `datasets/` | 4 domains (Agriculture, CS, Legal, Mix) from 428 textbooks, 600K–5M tokens. Compare chunk-based vs. graph-based vs. full-context retrieval accuracy. |
+| P1 | memory/022 | **MemoryBench procedural subset** | [Paper](https://arxiv.org/html/2510.17281v1) | Reference methodology; 20K cases across 3 domains | Procedural memory evaluation: inject explicit feedback (like/dislike) and implicit feedback (copy, session-close). Verify subsequent responses improve on same task type. |
+| P2 | memory/022 | **Letta dynamic memory eval** | [Blog](https://www.letta.com/blog/benchmarking-ai-agent-memory) | Reference | Tests whether agent learns *when* to use memory tools, not just retrieval accuracy. Letta (formerly MemGPT) pioneered OS-inspired hierarchical memory with virtual context paging. Adapt for feedback-loop testing. |
+| P0 | memory/023 | **GraphRAG-Bench** (ICLR 2026) | [GitHub](https://github.com/GraphRAG-Bench/GraphRAG-Benchmark) / [HuggingFace](https://huggingface.co/datasets/GraphRAG-Bench/GraphRAG-Bench) | `datasets.load_dataset("GraphRAG-Bench/GraphRAG-Bench")` | 16 disciplines, multi-format questions. Accepted at ICLR 2026. Use to validate that agent-scoped graph partitions return correct answers only from that agent's subgraph. |
+| P0 | memory/023 | **Zone-scoped HERB partitions** (local) | `benchmarks/herb/enterprise-context/` | Already in repo | Partition HERB data by department (eng/sales). Store as separate agent memories. Verify cross-agent isolation while shared memories remain accessible. |
 
 ### 4.8 — Search
 
@@ -396,6 +419,29 @@ as reference data, evaluation methodology, and ground-truth baselines.
 | search/007 | Code search (Zoekt) | auto,search | Trigram index works |
 | search/008 | Search daemon warmup | auto,search | Zero cold-start |
 | search/009 | Embedding cache dedup | auto,search,perf | 90%+ cache hit on repeated content |
+
+#### Benchmark Datasets & Sources for search + RAG (search/002–009, llm/003)
+
+Benchmarks for evaluating search accuracy, retrieval quality, and RAG pipeline
+correctness. Use [RAGAS](https://docs.ragas.io/) framework metrics (faithfulness,
+context precision/recall, answer relevancy) alongside traditional EM/F1/BLEU/ROUGE.
+
+**Evaluation methodology:** Use RAGAS for reference-free RAG evaluation (no ground
+truth needed for faithfulness/relevancy). Use EM + F1 for ground-truth benchmarks.
+Use NDCG@k + MRR for retrieval ranking quality. Use LLM-as-judge for open-ended
+answer quality.
+
+| Priority | Test ID | Benchmark / Dataset | Source | How to Obtain | What It Provides |
+|----------|---------|-------------------|--------|---------------|------------------|
+| P0 | search/005, llm/003 | **HERB Q&A** (local) | `benchmarks/herb/qa/` | Already in repo — 815 answerable + 699 unanswerable questions | Project-specific ground truth. Primary eval dataset for search accuracy and RAG pipeline. Score with EM + F1 against ground truth. |
+| P0 | search/002, llm/003 | **HotPotQA** (EMNLP 2018) | [Website](https://hotpotqa.github.io/) / [HuggingFace](https://huggingface.co/datasets/hotpotqa/hotpot_qa) | `datasets.load_dataset("hotpotqa/hotpot_qa")` | 113K multi-hop Q&A pairs with sentence-level supporting facts. De facto standard for RAG and multi-hop retrieval. Use distractor setting (10 paragraphs, 2 relevant) to test retrieval precision. |
+| P0 | search/002 | **BEIR** (NeurIPS 2021) | [GitHub](https://github.com/beir-cellar/beir) / [HuggingFace](https://huggingface.co/BeIR) | `pip install beir` | 15+ heterogeneous IR datasets (NFCorpus, SciFact, FiQA, etc.). Standard benchmark for semantic search / embedding quality. Use NDCG@10 metric. Pick 3–4 domain-relevant subsets (e.g., SciFact, FiQA, NFCorpus) for CI. |
+| P1 | llm/003 | **MultiHop-RAG** (COLM 2024) | [GitHub](https://github.com/yixuantt/MultiHop-RAG) | `git clone https://github.com/yixuantt/MultiHop-RAG` | Multi-hop queries over news articles with ground-truth evidence chains. Tests retrieval chaining and evidence linking — critical for RAG pipelines that must reason across multiple documents. |
+| P1 | llm/003 | **MuSiQue** | [GitHub](https://github.com/stonybrooknlp/musique) / [HuggingFace](https://huggingface.co/datasets/drt/musique) | `datasets.load_dataset("drt/musique")` | Multi-hop QA requiring compositional reasoning (2–4 hops). Harder than HotPotQA — includes unanswerable questions and decomposition annotations. Use alongside HotPotQA for multi-hop coverage. |
+| P1 | search/006 | **Natural Questions** (Google) | [HuggingFace](https://huggingface.co/datasets/google-research-datasets/natural_questions) | `datasets.load_dataset("google-research-datasets/natural_questions")` | 300K+ real Google search queries with Wikipedia answers. Single-hop QA baseline. Use to validate query expansion improves recall over raw queries. |
+| P1 | llm/003 | **RAGAS framework** | [GitHub](https://github.com/explodinggradients/ragas) / [Docs](https://docs.ragas.io/) | `pip install ragas` | Reference-free RAG evaluation framework. Metrics: faithfulness (no hallucination), answer relevancy, context precision, context recall. Use for automated CI evaluation without ground truth. |
+| P1 | search/002 | **MTEB Retrieval** (ICLR 2025) | [GitHub](https://github.com/embeddings-benchmark/mteb) / [Leaderboard](https://huggingface.co/spaces/mteb/leaderboard) | `pip install mteb` | Massive Text Embedding Benchmark. Use retrieval subset to validate embedding model selection. Compare our embedding model against MTEB leaderboard baselines. |
+| P2 | search/007 | **CodeSearchNet** | [GitHub](https://github.com/github/CodeSearchNet) | `git clone https://github.com/github/CodeSearchNet` | 2M (comment, code) pairs across 6 languages (Python, JS, Ruby, Go, Java, PHP). Human relevance judgements for evaluation. Use NDCG metric. Benchmark concluded but dataset still valuable for code search quality testing. |
 
 ### 4.9 — Pay
 


### PR DESCRIPTION
## Summary

- **Priority-rank all memory benchmarks** (memory/014–023) with P0/P1/P2 tiers based on dataset availability, community validation, and direct applicability
- **Add MemoryArena** (Feb 2026) — newest benchmark revealing agents saturating LoCoMo still fail on causally interdependent multi-session agentic tasks
- **Add search/RAG benchmark table** — previously missing; covers search/002–009 and llm/003 with HotPotQA, BEIR, MultiHop-RAG, MuSiQue, Natural Questions, RAGAS framework, MTEB, and CodeSearchNet
- **Add competitive baselines** — document MemGPT/Letta (74% LoCoMo), Mem0 (66.9%), Zep (75.1%) as systems to benchmark against, with LoCoMo reliability caveat (24% swing between groups)
- **Fix TOFU repo link** — updated from `locuslab/tofu` to `locuslab/open-unlearning` (NeurIPS D&B 2025), added R-TOFU reference

### Priority Breakdown (Memory)

| Priority | Count | Examples |
|----------|-------|---------|
| P0 (Must Have) | 10 | LongMemEval, LoCoMo, MemoryAgentBench, TOFU, GraphRAG-Bench, HERB |
| P1 (Should Have) | 7 | MemoryArena, Zep/Graphiti, Cognee, Mem0 methodology, LightRAG |
| P2 (Nice to Have) | 4 | Machine Unlearning survey, Custom corruption harness, Letta refs |

### Priority Breakdown (Search/RAG)

| Priority | Count | Examples |
|----------|-------|---------|
| P0 | 3 | HERB Q&A, HotPotQA, BEIR |
| P1 | 5 | MultiHop-RAG, MuSiQue, Natural Questions, RAGAS, MTEB |
| P2 | 1 | CodeSearchNet |

## Test plan

- [ ] Verify all benchmark URLs resolve correctly
- [ ] Verify HuggingFace dataset identifiers load with `datasets.load_dataset()`
- [ ] Confirm MemoryArena datasets are downloadable
- [ ] Validate TOFU loads from `locuslab/open-unlearning`